### PR TITLE
Change non-existent `WPElement` type to `Element`

### DIFF
--- a/templates/acronym-format/files/src/edit.js.mustache
+++ b/templates/acronym-format/files/src/edit.js.mustache
@@ -21,7 +21,7 @@ import AcronymPopover from './popover';
  * @param {Object}   props.value      The value of the rich text.
  * @param {Object}   props.contentRef Reference to the editable content.
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 function AcronymEdit( { isActive, onChange, value, contentRef } ) {
 	{{#isStartVariant}}

--- a/templates/acronym-format/files/src/popover.js.mustache
+++ b/templates/acronym-format/files/src/popover.js.mustache
@@ -20,7 +20,7 @@ import { acronymFormat, name } from './acronym';
  * @param {Function} props.onChange   Function to apply the format.
  * @param {Function} props.onClose    Function to close the popover.
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 function AcronymPopover( { value, contentRef, onChange, onClose } ) {
 	const popoverAnchor = useAnchor( {

--- a/templates/bdc/templates/block/edit.js.mustache
+++ b/templates/bdc/templates/block/edit.js.mustache
@@ -16,7 +16,7 @@ import './editor.scss';
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit() {
 	return (

--- a/templates/bdc/templates/block/save.js.mustache
+++ b/templates/bdc/templates/block/save.js.mustache
@@ -12,7 +12,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function save() {
 	return (

--- a/templates/customize-build-process/files/block/edit.js.mustache
+++ b/templates/customize-build-process/files/block/edit.js.mustache
@@ -15,7 +15,7 @@ import './editor.scss';
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit() {
 	return (

--- a/templates/editorial-notes/files/plugin/README.md.mustache
+++ b/templates/editorial-notes/files/plugin/README.md.mustache
@@ -119,9 +119,9 @@ Register the new filter and add the callback:
 /**
 * Add a custom control to the block inspector controls for every block.
 *
-* @param {WPElement} BlockEdit The original block edit component.
+* @param {Element} BlockEdit The original block edit component.
 *
-* @return {WPElement} Element to render.
+* @return {Element} Element to render.
 */
 function addEditorNotesField( BlockEdit ) {
    return ( props ) => {
@@ -154,9 +154,9 @@ Let’s add that now along with the `PanelBody` and `TextareaControl`:
 /**
 * Add a custom control to the block inspector controls for every block.
 *
-* @param {WPElement} BlockEdit The original block edit component.
+* @param {Element} BlockEdit The original block edit component.
 *
-* @return {WPElement} Element to render.
+* @return {Element} Element to render.
 */
 function addEditorNotesField( BlockEdit ) {
    return ( props ) => {
@@ -204,9 +204,9 @@ Next, we’re going to add a some code to make this run a little faster. We only
 /**
 * Add a custom control to the block inspector controls for every block.
 *
-* @param {WPElement} BlockEdit The original block edit component.
+* @param {Element} BlockEdit The original block edit component.
 *
-* @return {WPElement} Element to render.
+* @return {Element} Element to render.
 */
 function addEditorNotesField( BlockEdit ) {
    return ( props ) => {
@@ -259,9 +259,9 @@ For this we’re going to use the [`editor.BlockListBlock`](https://developer.wo
 /**
 * Add a custom class and CSS to show when a block has notes.
 *
-* @param {WPElement} BlockListBlock The original block list block component.
+* @param {Element} BlockListBlock The original block list block component.
 *
-* @return {WPElement} Element to render.
+* @return {Element} Element to render.
 */
 function addNotesDisplayClass( BlockListBlock ) {
    return ( props ) => {

--- a/templates/editorial-notes/files/src/notes-field.js.mustache
+++ b/templates/editorial-notes/files/src/notes-field.js.mustache
@@ -41,9 +41,9 @@ addFilter(
 /**
  * Add a custom control to the block inspector controls for every block.
  *
- * @param {WPElement} BlockEdit The original block edit component.
+ * @param {Element} BlockEdit The original block edit component.
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 function addEditorNotesField( BlockEdit ) {
 	return ( props ) => {
@@ -88,9 +88,9 @@ addFilter(
 /**
  * Add a custom class and CSS to show when a block has notes.
  *
- * @param {WPElement} BlockListBlock The original block list block component.
+ * @param {Element} BlockListBlock The original block list block component.
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 function addNotesDisplayClass( BlockListBlock ) {
 	return ( props ) => {

--- a/templates/testimonial/files/block/edit.js.mustache
+++ b/templates/testimonial/files/block/edit.js.mustache
@@ -9,7 +9,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( props ) {
 	return (
@@ -35,7 +35,7 @@ import { useEntityProp } from '@wordpress/core-data';
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @param {*} param0
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( {
 	attributes: { authorName },

--- a/templates/testimonial/files/plugin/README.md.mustache
+++ b/templates/testimonial/files/plugin/README.md.mustache
@@ -76,7 +76,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( props ) {
 	return (
@@ -102,7 +102,7 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( props ) {
 	return (
@@ -145,7 +145,7 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( { attributes: { authorName }, setAttributes } ) {
 	return (
@@ -198,7 +198,7 @@ import { useEntityProp } from '@wordpress/core-data';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( {
 	attributes: { authorName },
@@ -251,7 +251,7 @@ import { useEntityProp } from '@wordpress/core-data';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( {
 	attributes: { authorName },
@@ -300,7 +300,7 @@ import { useEntityProp } from '@wordpress/core-data';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( {
 	attributes: { authorName },
@@ -376,7 +376,7 @@ import { useEntityProp } from '@wordpress/core-data';
  * editor. This represents what the editor will render when the block is used.
  *
  * @param {*} props
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( {
 	attributes: { authorName },

--- a/templates/transforms/files/block/edit.js.mustache
+++ b/templates/transforms/files/block/edit.js.mustache
@@ -15,7 +15,7 @@ import Autobots from './icon';
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
- * @return {WPElement} Element to render.
+ * @return {Element} Element to render.
  */
 export default function Edit( { attributes: { message }, setAttributes } ) {
 	return (


### PR DESCRIPTION
While working on some recipes, I noticed that the code editor was giving me a warning about the `WPElement` type.

![wp-element](https://github.com/ryanwelcher/block-developer-cookbook/assets/54422211/3665a2fd-9e81-4ab6-b210-71f1e70bfb35)


This type was removed by the following PR and does not appear to exist anymore.

https://github.com/WordPress/gutenberg/pull/54908

> I also removed the internal WPComponent and WPElement types for clarity. It impacts a high number of files though.