### PR TITLE
WordCounter: Use hard-coded store name in one code example

### DIFF
--- a/templates/word-counter/files/plugin/README.md.mustache
+++ b/templates/word-counter/files/plugin/README.md.mustache
@@ -153,7 +153,7 @@ import { useSelect } from '@wordpress/data';
 const Render = () => {
 	// Get the blocks from the editor.
 	const blocks = useSelect(
-		( select ) => select( blockEditorStore ).getBlocks(),
+		( select ) => select( 'core/block-editor' ).getBlocks(),
 		[]
 	);
 


### PR DESCRIPTION
Here's what's said about this code:

> In order for us to access a selector, we need to know the name of the store where it is defined and pass it to the select function. For the most part, stores are named as follows core/{package-name} so in our case the getBlocks selector is in the @wordpress/block-editor package to the store name is core/block-editor.

Therefore, we need to use the hard-coded store name since we haven't imported the store yet.