### PR TITLE
Simple Side Effect: Add a backslash to WP_HTML_Tag_Processor

### DIFF
--- a/templates/simple-fade-effect/files/plugin/$slug.php.mustache
+++ b/templates/simple-fade-effect/files/plugin/$slug.php.mustache
@@ -77,7 +77,7 @@ function enqueue_files_for_core_blocks( $block_content, $block ) {
 	// Enqueue the same script for more than one block type.
 	if ( 'core/cover' === $block['blockName'] || 'core/image' === $block['blockName'] ) {
 		// Append the the fader class to to the block wrapper.
-		$tag = new WP_HTML_Tag_Processor( $block_content );
+		$tag = new \WP_HTML_Tag_Processor( $block_content );
 		if ( $tag->next_tag() ) {
 			$tag->add_class( 'fader' );
 		}
@@ -101,7 +101,7 @@ function enqueue_files_for_core_blocks( $block_content, $block ) {
 function enqueue_files_for_one_core_block( $block_content ) {
 	// Enqueue the script for a single block type.
 	// Append the the fader class to to the block wrapper.
-	$tag = new WP_HTML_Tag_Processor( $block_content );
+	$tag = new \WP_HTML_Tag_Processor( $block_content );
 	if ( $tag->next_tag() ) {
 		$tag->add_class( 'fader' );
 	}

--- a/templates/simple-fade-effect/files/plugin/README.md.mustache
+++ b/templates/simple-fade-effect/files/plugin/README.md.mustache
@@ -65,7 +65,7 @@ function enqueue_files_for_core_blocks( $block_content, $block ) {
 	if ( 'core/cover' === $block['blockName'] || 'core/image' === $block['blockName'] ) {
 
 		// Append the the fader class to to the block wrapper.
-		$tag = new WP_HTML_Tag_Processor( $block_content );
+		$tag = new \WP_HTML_Tag_Processor( $block_content );
 		if ( $tag->next_tag() ) {
 			$tag->add_class( 'fader' );
 		}
@@ -101,7 +101,7 @@ add_filter( 'render_block_core/image', __NAMESPACE__ . '\enqueue_files_for_one_c
 function enqueue_files_for_one_core_block( $block_content ) {
 	// Enqueue the script for a single block type.
 	// Append the the fader class to to the block wrapper.
-	$tag = new WP_HTML_Tag_Processor( $block_content );
+	$tag = new \WP_HTML_Tag_Processor( $block_content );
 	if ( $tag->next_tag() ) {
 		$tag->add_class( 'fader' );
 	}


### PR DESCRIPTION
Without this backslash, a critical error would occur because the namespace already exists.

```
PHP Fatal error:  Uncaught Error: Class "BlockDevelopersCookbook\WP_HTML_Tag_Processor" not found in /var/www/html/wp-content/plugins/simple-fade-effect/simple-fade-effect.php:63
```