### PR TITLE
Add accessible button text to light-dark-mode block

### DIFF
--- a/templates/dark-light-mode/files/src/render.php.mustache
+++ b/templates/dark-light-mode/files/src/render.php.mustache
@@ -36,7 +36,7 @@ wp_interactivity_state(
     >
         <span class="toggle__display" hidden></span>
         <span class="screen-reader-text">
-            <?php esc_html_e( 'Switch to dark mode', 'dark-light-mode' ); ?>
+            <?php esc_html_e( 'View in dark mode', 'dark-light-mode' ); ?>
         </span>
     </button>
 </div>
@@ -47,7 +47,7 @@ wp_interactivity_state(
 <button class="toggle" type="button">
 	<span class="toggle__display" hidden></span>
 	<span class="screen-reader-text">
-		<?php esc_html_e( 'Switch to dark mode', 'dark-light-mode' ); ?>
+		<?php esc_html_e( 'View in dark mode', 'dark-light-mode' ); ?>
 	</span>
 </button>
 </div>

--- a/templates/dark-light-mode/files/src/render.php.mustache
+++ b/templates/dark-light-mode/files/src/render.php.mustache
@@ -35,6 +35,9 @@ wp_interactivity_state(
         type="button"
     >
         <span class="toggle__display" hidden></span>
+        <span class="screen-reader-text">
+            <?php esc_html_e( 'Switch to dark mode', 'dark-light-mode' ); ?>
+        </span>
     </button>
 </div>
 {{/isCompletedVariant}}
@@ -43,6 +46,9 @@ wp_interactivity_state(
 <div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 <button class="toggle" type="button">
 	<span class="toggle__display" hidden></span>
+	<span class="screen-reader-text">
+		<?php esc_html_e( 'Switch to dark mode', 'dark-light-mode' ); ?>
+	</span>
 </button>
 </div>
 {{/isStartVariant}}


### PR DESCRIPTION
Hi Ryan,

Brandon here. Thank you so much for doing the workshop today. It's awesome. 

If you don't mind, I'd like to submit a PR to add an accessible button text to the `light-dark-mode` block. 

#### How VoiceOver announces the button
This is tested on macOS (Version 15.3) with Safari (Version 18.3).

- VoiceOver will announce "Switch to dark mode, toggle button" prior to pressing the toggle button.
    <img width="1440" alt="VoiceOver announces switch to dark mode, toggle button when the toggle button is focused by VoiceOver" src="https://github.com/user-attachments/assets/2824d6fc-5a9a-4608-990d-2e9cd0c479eb" />

- Once pressed, VoiceOver will announce "selected" to user.
    <img width="1440" alt="VoiceOver announces selected when the toggle button is pressed" src="https://github.com/user-attachments/assets/906bf884-e450-498a-8e59-5a4b103df2c0" />

- If user navigate to other elements and then back to the toggle button, VoiceOver will announce "Switch to dark mode, selected, toggle button" thanks to the `aria-pressed=true` attribute that is already present on the button.
    <img width="1440" alt="VoiceOver announces switch to dark mode, selected, toggle button when VoiceOver navigates to other elements and then back to the toggle button" src="https://github.com/user-attachments/assets/724816e7-848e-416f-8cc6-7a532f344b09" />

Although I'm not sure if "Switch to dark mode" is the best text here. I will ask around and probably come back to a follow-up comment.
